### PR TITLE
Update winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,5 @@ exclude = [".gitignore"]
 default-target = "x86_64-pc-windows-msvc"
 
 [target.'cfg(windows)'.dependencies]
-kernel32-sys = "0.2.2"
-winapi = "0.2.8"
-ws2_32-sys = "0.2.1"
+winapi = { version = "0.3.9", features = ["winsock2", "ws2def", "minwinbase", "ntdef", "processthreadsapi", "handleapi", "ws2tcpip", "winbase"] }
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,6 @@
 extern crate winapi;
 
 #[cfg(windows)]
-extern crate ws2_32;
-
-#[cfg(windows)]
-extern crate kernel32;
-
-#[cfg(windows)]
 extern crate tempdir;
 
 #[cfg(windows)]

--- a/src/stdnet/ext.rs
+++ b/src/stdnet/ext.rs
@@ -10,13 +10,17 @@ use std::mem;
 use std::os::windows::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use winapi::{
-    c_int, u_long, BOOL, DWORD, FALSE, GUID, LPDWORD, LPINT, LPOVERLAPPED, LPSOCKADDR, OVERLAPPED,
-    PVOID, SIO_GET_EXTENSION_FUNCTION_POINTER, SOCKADDR, SOCKADDR_STORAGE, SOCKET, SOCKET_ERROR,
-    SOL_SOCKET, TRUE, WSABUF, WSA_IO_PENDING,
+use winapi::ctypes::c_int;
+use winapi::shared::guiddef::GUID;
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, LPDWORD, LPINT, TRUE};
+use winapi::shared::ntdef::PVOID;
+use winapi::shared::ws2def::{
+    LPSOCKADDR, SIO_GET_EXTENSION_FUNCTION_POINTER, SOCKADDR, SOCKADDR_STORAGE, SOL_SOCKET, WSABUF,
 };
-use ws2_32::{
-    bind, setsockopt, WSAGetLastError, WSAGetOverlappedResult, WSAIoctl, WSARecv, WSASend,
+use winapi::um::minwinbase::{LPOVERLAPPED, OVERLAPPED};
+use winapi::um::winsock2::{
+    bind, setsockopt, u_long, WSAGetLastError, WSAGetOverlappedResult, WSAIoctl, WSARecv, WSASend,
+    SOCKET, SOCKET_ERROR, WSA_IO_PENDING,
 };
 
 use super::net::{UnixListener, UnixStream};

--- a/src/stdnet/mod.rs
+++ b/src/stdnet/mod.rs
@@ -5,8 +5,8 @@ use std::mem;
 use std::os::raw::{c_char, c_int};
 use std::path::Path;
 
-use winapi::SOCKADDR;
-use ws2_32::WSAGetLastError;
+use winapi::shared::ws2def::SOCKADDR;
+use winapi::um::winsock2::WSAGetLastError;
 
 mod ext;
 mod net;
@@ -15,9 +15,12 @@ mod socket;
 mod c {
     use std::ffi::CStr;
     use std::fmt;
-    use winapi::{self, ADDRESS_FAMILY, CHAR};
+    use winapi::{
+        self,
+        shared::{ntdef::CHAR, ws2def::ADDRESS_FAMILY},
+    };
 
-    pub const AF_UNIX: ADDRESS_FAMILY = winapi::AF_UNIX as _;
+    pub const AF_UNIX: ADDRESS_FAMILY = winapi::shared::ws2def::AF_UNIX as _;
 
     #[allow(non_camel_case_types)]
     #[derive(Copy, Clone)]

--- a/src/stdnet/net.rs
+++ b/src/stdnet/net.rs
@@ -7,8 +7,9 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 use std::path::Path;
 use std::time::Duration;
 
-use winapi::{SO_RCVTIMEO, SO_SNDTIMEO};
-use ws2_32::{bind, connect, getpeername, getsockname, listen};
+use winapi::um::winsock2::{
+    bind, connect, getpeername, getsockname, listen, SO_RCVTIMEO, SO_SNDTIMEO,
+};
 
 use super::socket::{init, Socket};
 use super::{c, cvt, from_sockaddr_un, sockaddr_un, SocketAddr};


### PR DESCRIPTION
- Updates winapi to 0.3.9 
- Get rid of -sys dependencies and use winapi instead.