### PR TITLE
Replace deprecated tempdir with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ default-target = "x86_64-pc-windows-msvc"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winsock2", "ws2def", "minwinbase", "ntdef", "processthreadsapi", "handleapi", "ws2tcpip", "winbase"] }
-tempdir = "0.3"
+tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate winapi;
 
 #[cfg(windows)]
-extern crate tempdir;
+extern crate tempfile;
 
 #[cfg(windows)]
 mod stdnet;

--- a/src/stdnet/net.rs
+++ b/src/stdnet/net.rs
@@ -178,9 +178,8 @@ impl UnixStream {
     pub fn pair() -> io::Result<(Self, Self)> {
         use std::sync::{Arc, RwLock};
         use std::thread::spawn;
-        use tempdir::TempDir;
 
-        let dir = TempDir::new("rust-uds-windows")?;
+        let dir = tempfile::tempdir()?;
         let file_path = dir.path().join("socket");
         let a: Arc<RwLock<Option<io::Result<UnixStream>>>> = Arc::new(RwLock::new(None));
         let ul = UnixListener::bind(&file_path).unwrap();
@@ -603,13 +602,13 @@ impl<'a> Iterator for Incoming<'a> {
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use std::io::{self, Read, Write};
     use std::path::PathBuf;
     use std::thread;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::TempDir;
 
     use super::*;
 
@@ -623,7 +622,7 @@ mod test {
     }
 
     fn tmpdir() -> Result<(TempDir, PathBuf), io::Error> {
-        let dir = TempDir::new("mio-uds-windows")?;
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("sock");
         Ok((dir, path))
     }
@@ -710,7 +709,7 @@ mod test {
 
     #[test]
     fn long_path() {
-        let dir = or_panic!(TempDir::new("mio-uds-windows"));
+        let dir = or_panic!(tempfile::tempdir());
         let socket_path = dir.path().join(
             "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfa\
              sasdfasdfasdasdfasdfasdfadfasdfasdfasdfasdfasdf",


### PR DESCRIPTION
`tempdir` crate has been deprecated.

https://github.com/rust-lang-deprecated/tempdir#deprecation-note

> ## Deprecation Note
> The tempdir crate is being merged into tempfile and is available in 3.x. Please direct new issues and pull requests to tempfile.

See also https://rustsec.org/advisories/RUSTSEC-2018-0017.html.