### PR TITLE
Use range for windows-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".gitignore", ".github"]
 default-target = "x86_64-pc-windows-msvc"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.59", features = [
+windows-sys = { version = ">=0.59, <0.62", features = [
     "Win32_Networking_WinSock",
     "Win32_Foundation",
     "Win32_System_Threading",


### PR DESCRIPTION
New versions of windows-sys do not guarantee compatibility with existing code. It is safer to set a defined version range that is known to be compatible.