### PR TITLE
Remove dependency on `memoffset`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ windows-sys = { version = ">=0.60, <0.62", features = [
     "Win32_System_IO",
 ] }
 tempfile = "3"
-
-[dependencies]
-memoffset = "0.9.0"

--- a/src/stdnet/ext.rs
+++ b/src/stdnet/ext.rs
@@ -625,7 +625,7 @@ impl AcceptAddrsBuf {
     }
 
     fn args(&self) -> (*mut core::ffi::c_void, u32, u32, u32) {
-        let remote_offset = memoffset::offset_of!(AcceptAddrsBuf, remote);
+        let remote_offset = core::mem::offset_of!(AcceptAddrsBuf, remote);
         (
             self as *const _ as *mut _,
             0,


### PR DESCRIPTION
Hi, I may or may not have used your crate but I'd like to say a quick thank you for it anyway!
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77 which I believe is at or below your MSRV.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please test anyway.
I hope we can all enjoy the benefits of one less dependency :)